### PR TITLE
Cassandra driver refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # migrate
 
-[![Build Status](https://travis-ci.org/mattes/migrate.svg?branch=master)](https://travis-ci.org/mattes/migrate)
-[![GoDoc](https://godoc.org/github.com/mattes/migrate?status.svg)](https://godoc.org/github.com/mattes/migrate)
+[![Build Status](https://travis-ci.org/heetch/migrate.svg?branch=master)](https://travis-ci.org/heetch/migrate)
+[![GoDoc](https://godoc.org/github.com/heetch/migrate?status.svg)](https://godoc.org/github.com/heetch/migrate)
 
-A migration helper written in Go. Use it in your existing Golang code 
-or run commands via the CLI. 
+A migration helper written in Go. Use it in your existing Golang code
+or run commands via the CLI.
 
 ```
-GoCode   import github.com/mattes/migrate/migrate
-CLI      go get -u github.com/mattes/migrate
+GoCode   import github.com/heetch/migrate/migrate
+CLI      go get -u github.com/heetch/migrate
 ```
 
 __Features__
 
-* Super easy to implement [Driver interface](http://godoc.org/github.com/mattes/migrate/driver#Driver).
+* Super easy to implement [Driver interface](http://godoc.org/github.com/heetch/migrate/driver#Driver).
 * Gracefully quit running migrations on ``^C``.
 * No magic search paths routines, no hard-coded config files.
 * CLI is build on top of the ``migrate package``.
@@ -21,20 +21,20 @@ __Features__
 
 ## Available Drivers
 
- * [PostgreSQL](https://github.com/mattes/migrate/tree/master/driver/postgres)
- * [Cassandra](https://github.com/mattes/migrate/tree/master/driver/cassandra)
- * [SQLite](https://github.com/mattes/migrate/tree/master/driver/sqlite3)
- * [MySQL](https://github.com/mattes/migrate/tree/master/driver/mysql) ([experimental](https://github.com/mattes/migrate/issues/1#issuecomment-58728186))
+ * [PostgreSQL](https://github.com/heetch/migrate/tree/master/driver/postgres)
+ * [Cassandra](https://github.com/heetch/migrate/tree/master/driver/cassandra)
+ * [SQLite](https://github.com/heetch/migrate/tree/master/driver/sqlite3)
+ * [MySQL](https://github.com/heetch/migrate/tree/master/driver/mysql) ([experimental](https://github.com/heetch/migrate/issues/1#issuecomment-58728186))
  * Bash (planned)
 
-Need another driver? Just implement the [Driver interface](http://godoc.org/github.com/mattes/migrate/driver#Driver) and open a PR.
+Need another driver? Just implement the [Driver interface](http://godoc.org/github.com/heetch/migrate/driver#Driver) and open a PR.
 
 
 ## Usage from Terminal
 
 ```bash
 # install
-go get github.com/mattes/migrate
+go get github.com/heetch/migrate
 
 # create new migration file in path
 migrate -url driver://url -path ./migrations create migration_file_xyz
@@ -73,10 +73,10 @@ migrate -url driver://url -path ./migrations goto v
 
 ## Usage in Go
 
-See GoDoc here: http://godoc.org/github.com/mattes/migrate/migrate
+See GoDoc here: http://godoc.org/github.com/heetch/migrate/migrate
 
 ```go
-import "github.com/mattes/migrate/migrate"
+import "github.com/heetch/migrate/migrate"
 
 // use synchronous versions of migration functions ...
 allErrors, ok := migrate.UpSync("driver://url", "./path")
@@ -104,7 +104,7 @@ The format of migration files looks like this:
 ...
 ```
 
-Why two files? This way you could still do sth like 
+Why two files? This way you could still do sth like
 ``psql -f ./db/migrations/001_initial_plan_to_do_sth.up.sql`` and there is no
 need for any custom markup language to divide up and down migrations. Please note
 that the filename extension depends on the driver.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # migrate
 
-[![Build Status](https://travis-ci.org/heetch/migrate.svg?branch=master)](https://travis-ci.org/heetch/migrate)
-[![GoDoc](https://godoc.org/github.com/heetch/migrate?status.svg)](https://godoc.org/github.com/heetch/migrate)
-
 A migration helper written in Go. Use it in your existing Golang code
 or run commands via the CLI.
 

--- a/driver/bash/bash.go
+++ b/driver/bash/bash.go
@@ -2,8 +2,8 @@
 package bash
 
 import (
-	"github.com/mattes/migrate/file"
-	_ "github.com/mattes/migrate/migrate/direction"
+	"github.com/heetch/migrate/file"
+	_ "github.com/heetch/migrate/migrate/direction"
 )
 
 type Driver struct {

--- a/driver/cassandra/cassandra.go
+++ b/driver/cassandra/cassandra.go
@@ -62,6 +62,8 @@ func (driver *Driver) ensureVersionTableExists() error {
 	if err := driver.session.Query("CREATE TABLE IF NOT EXISTS " + tableName +
 		" (driver_version int," +
 		"version bigint," +
+		"file_name text," +
+		"applied_at timestamp," +
 		"PRIMARY KEY (driver_version,  version)" +
 		") WITH CLUSTERING ORDER BY (version DESC);").Exec(); err != nil {
 		return err
@@ -94,7 +96,7 @@ func (driver *Driver) Migrate(f file.File, pipe chan interface{}) {
 	}
 
 	if f.Direction == direction.Up {
-		if err := driver.session.Query("INSERT INTO "+tableName+" (driver_version, version) VALUES (1, ?)", f.Version).Exec(); err != nil {
+		if err := driver.session.Query("INSERT INTO "+tableName+" (driver_version, version, file_name, applied_at) VALUES (1, ?, ?, dateof(now()))", f.Version, f.FileName).Exec(); err != nil {
 			pipe <- err
 			return
 		}

--- a/driver/cassandra/cassandra.go
+++ b/driver/cassandra/cassandra.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/gocql/gocql"
-	"github.com/mattes/migrate/file"
-	"github.com/mattes/migrate/migrate/direction"
+	"github.com/heetch/migrate/file"
+	"github.com/heetch/migrate/migrate/direction"
 )
 
 type Driver struct {

--- a/driver/cassandra/cassandra_test.go
+++ b/driver/cassandra/cassandra_test.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/gocql/gocql"
-	"github.com/mattes/migrate/file"
-	"github.com/mattes/migrate/migrate/direction"
-	pipep "github.com/mattes/migrate/pipe"
+	"github.com/heetch/migrate/file"
+	"github.com/heetch/migrate/migrate/direction"
+	pipep "github.com/heetch/migrate/pipe"
 )
 
 func TestMigrate(t *testing.T) {

--- a/driver/cassandra/cassandra_test.go
+++ b/driver/cassandra/cassandra_test.go
@@ -47,8 +47,8 @@ func TestMigrate(t *testing.T) {
 	files := []file.File{
 		{
 			Path:      "/foobar",
-			FileName:  "001_foobar.up.sql",
-			Version:   1,
+			FileName:  "20150801233454_foobar.up.sql",
+			Version:   20150801233454,
 			Name:      "foobar",
 			Direction: direction.Up,
 			Content: []byte(`
@@ -62,8 +62,8 @@ func TestMigrate(t *testing.T) {
 		},
 		{
 			Path:      "/foobar",
-			FileName:  "002_foobar.down.sql",
-			Version:   1,
+			FileName:  "20150801233454_foobar.down.sql",
+			Version:   20150801233454,
 			Name:      "foobar",
 			Direction: direction.Down,
 			Content: []byte(`
@@ -72,8 +72,8 @@ func TestMigrate(t *testing.T) {
 		},
 		{
 			Path:      "/foobar",
-			FileName:  "002_foobar.up.sql",
-			Version:   2,
+			FileName:  "20150803233454_foobar.up.sql",
+			Version:   20150803233454,
 			Name:      "foobar",
 			Direction: direction.Up,
 			Content: []byte(`
@@ -91,6 +91,14 @@ func TestMigrate(t *testing.T) {
 		t.Fatal(errs)
 	}
 
+	version, err := d.Version()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != 20150801233454 {
+		t.Fatal("Unable to migrate up. Expected 20150801233454 but get ", version)
+	}
+
 	pipe = pipep.New()
 	go d.Migrate(files[1], pipe)
 	errs = pipep.ReadErrors(pipe)
@@ -98,11 +106,27 @@ func TestMigrate(t *testing.T) {
 		t.Fatal(errs)
 	}
 
+	version, err = d.Version()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != 0 {
+		t.Fatal("Unable to migrate down. Expected 0 but get ", version)
+	}
+
 	pipe = pipep.New()
 	go d.Migrate(files[2], pipe)
 	errs = pipep.ReadErrors(pipe)
 	if len(errs) == 0 {
 		t.Error("Expected test case to fail")
+	}
+
+	version, err = d.Version()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != 0 {
+		t.Fatal("This migration should have failed, so we should get the last migration version 0 in here.", version)
 	}
 
 	if err := d.Close(); err != nil {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	neturl "net/url" // alias to allow `url string` func signature in New
 
-	"github.com/mattes/migrate/driver/bash"
-	"github.com/mattes/migrate/driver/cassandra"
-	"github.com/mattes/migrate/driver/mysql"
-	"github.com/mattes/migrate/driver/postgres"
-	"github.com/mattes/migrate/driver/sqlite3"
-	"github.com/mattes/migrate/file"
+	"github.com/heetch/migrate/driver/bash"
+	"github.com/heetch/migrate/driver/cassandra"
+	"github.com/heetch/migrate/driver/mysql"
+	"github.com/heetch/migrate/driver/postgres"
+	"github.com/heetch/migrate/driver/sqlite3"
+	"github.com/heetch/migrate/file"
 )
 
 // Driver is the interface type that needs to implemented by all drivers.

--- a/driver/mysql/README.md
+++ b/driver/mysql/README.md
@@ -1,6 +1,6 @@
 # MySQL Driver
 
-### See [issue #1](https://github.com/mattes/migrate/issues/1#issuecomment-58728186) before using this driver!
+### See [issue #1](https://github.com/heetch/migrate/issues/1#issuecomment-58728186) before using this driver!
 
 * Runs migrations in transcations.
   That means that if a migration failes, it will be safely rolled back.
@@ -21,4 +21,4 @@ See full [DSN (Data Source Name) documentation](https://github.com/go-sql-driver
 
 ## Authors
 
-* Matthias Kadenbach, https://github.com/mattes
+* Matthias Kadenbach, https://github.com/heetch

--- a/driver/mysql/README.md
+++ b/driver/mysql/README.md
@@ -21,4 +21,4 @@ See full [DSN (Data Source Name) documentation](https://github.com/go-sql-driver
 
 ## Authors
 
-* Matthias Kadenbach, https://github.com/heetch
+* Matthias Kadenbach, https://github.com/mattes

--- a/driver/mysql/mysql.go
+++ b/driver/mysql/mysql.go
@@ -7,12 +7,13 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/go-sql-driver/mysql"
-	"github.com/mattes/migrate/file"
-	"github.com/mattes/migrate/migrate/direction"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/heetch/migrate/file"
+	"github.com/heetch/migrate/migrate/direction"
 )
 
 type Driver struct {

--- a/driver/mysql/mysql_test.go
+++ b/driver/mysql/mysql_test.go
@@ -2,11 +2,12 @@ package mysql
 
 import (
 	"database/sql"
-	"github.com/mattes/migrate/file"
-	"github.com/mattes/migrate/migrate/direction"
-	pipep "github.com/mattes/migrate/pipe"
 	"strings"
 	"testing"
+
+	"github.com/heetch/migrate/file"
+	"github.com/heetch/migrate/migrate/direction"
+	pipep "github.com/heetch/migrate/pipe"
 )
 
 // TestMigrate runs some additional tests on Migrate().

--- a/driver/postgres/README.md
+++ b/driver/postgres/README.md
@@ -14,10 +14,10 @@ migrate -url postgres://user@host:port/database -path ./db/migrations create add
 migrate -url postgres://user@host:port/database -path ./db/migrations up
 migrate help # for more info
 
-# TODO(heetch): thinking about adding some custom flag to allow migration within schemas:
+# TODO(mattes): thinking about adding some custom flag to allow migration within schemas:
 -url="postgres://user@host:port/database?schema=name"
 ```
 
 ## Authors
 
-* Matthias Kadenbach, https://github.com/heetch
+* Matthias Kadenbach, https://github.com/mattes

--- a/driver/postgres/README.md
+++ b/driver/postgres/README.md
@@ -14,10 +14,10 @@ migrate -url postgres://user@host:port/database -path ./db/migrations create add
 migrate -url postgres://user@host:port/database -path ./db/migrations up
 migrate help # for more info
 
-# TODO(mattes): thinking about adding some custom flag to allow migration within schemas:
--url="postgres://user@host:port/database?schema=name" 
+# TODO(heetch): thinking about adding some custom flag to allow migration within schemas:
+-url="postgres://user@host:port/database?schema=name"
 ```
 
 ## Authors
 
-* Matthias Kadenbach, https://github.com/mattes
+* Matthias Kadenbach, https://github.com/heetch

--- a/driver/postgres/postgres.go
+++ b/driver/postgres/postgres.go
@@ -5,10 +5,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/lib/pq"
-	"github.com/mattes/migrate/file"
-	"github.com/mattes/migrate/migrate/direction"
 	"strconv"
+
+	"github.com/heetch/migrate/file"
+	"github.com/heetch/migrate/migrate/direction"
+	"github.com/lib/pq"
 )
 
 type Driver struct {

--- a/driver/postgres/postgres_test.go
+++ b/driver/postgres/postgres_test.go
@@ -2,10 +2,11 @@ package postgres
 
 import (
 	"database/sql"
-	"github.com/mattes/migrate/file"
-	"github.com/mattes/migrate/migrate/direction"
-	pipep "github.com/mattes/migrate/pipe"
 	"testing"
+
+	"github.com/heetch/migrate/file"
+	"github.com/heetch/migrate/migrate/direction"
+	pipep "github.com/heetch/migrate/pipe"
 )
 
 // TestMigrate runs some additional tests on Migrate().

--- a/driver/sqlite3/README.md
+++ b/driver/sqlite3/README.md
@@ -17,5 +17,5 @@ migrate help # for more info
 
 ## Authors
 
-* Matthias Kadenbach, https://github.com/mattes
+* Matthias Kadenbach, https://github.com/heetch
 * Caesar Wirth, https://github.com/cjwirth

--- a/driver/sqlite3/README.md
+++ b/driver/sqlite3/README.md
@@ -17,5 +17,5 @@ migrate help # for more info
 
 ## Authors
 
-* Matthias Kadenbach, https://github.com/heetch
+* Matthias Kadenbach, https://github.com/mattes
 * Caesar Wirth, https://github.com/cjwirth

--- a/driver/sqlite3/sqlite3.go
+++ b/driver/sqlite3/sqlite3.go
@@ -5,10 +5,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/mattes/migrate/file"
-	"github.com/mattes/migrate/migrate/direction"
-	"github.com/mattn/go-sqlite3"
 	"strings"
+
+	"github.com/heetch/migrate/file"
+	"github.com/heetch/migrate/migrate/direction"
+	"github.com/mattn/go-sqlite3"
 )
 
 type Driver struct {

--- a/driver/sqlite3/sqlite3_test.go
+++ b/driver/sqlite3/sqlite3_test.go
@@ -2,10 +2,11 @@ package sqlite3
 
 import (
 	"database/sql"
-	"github.com/mattes/migrate/file"
-	"github.com/mattes/migrate/migrate/direction"
-	pipep "github.com/mattes/migrate/pipe"
 	"testing"
+
+	"github.com/heetch/migrate/file"
+	"github.com/heetch/migrate/migrate/direction"
+	pipep "github.com/heetch/migrate/pipe"
 )
 
 // TestMigrate runs some additional tests on Migrate()

--- a/file/file.go
+++ b/file/file.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/mattes/migrate/migrate/direction"
 	"go/token"
 	"io/ioutil"
 	"path"
@@ -13,6 +12,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/heetch/migrate/migrate/direction"
 )
 
 var filenameRegex = `^([0-9]+)_(.*)\.(up|down)\.%s$`
@@ -296,8 +297,8 @@ func LineColumnFromOffset(data []byte, offset int) (line, column int) {
 // LinesBeforeAndAfter reads n lines before and after a given line.
 // Set lineNumbers to true, to prepend line numbers.
 func LinesBeforeAndAfter(data []byte, line, before, after int, lineNumbers bool) []byte {
-	// TODO(mattes): Trim empty lines at the beginning and at the end
-	// TODO(mattes): Trim offset whitespace at the beginning of each line, so that indentation is preserved
+	// TODO(heetch): Trim empty lines at the beginning and at the end
+	// TODO(heetch): Trim offset whitespace at the beginning of each line, so that indentation is preserved
 	startLine := line - before
 	endLine := line + after
 	lines := bytes.SplitN(data, []byte("\n"), endLine+1)

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -1,11 +1,12 @@
 package file
 
 import (
-	"github.com/mattes/migrate/migrate/direction"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/heetch/migrate/migrate/direction"
 )
 
 func TestParseFilenameSchema(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -1,19 +1,20 @@
 // Package main is the CLI.
 // You can use the CLI via Terminal.
-// import "github.com/mattes/migrate/migrate" for usage within Go.
+// import "github.com/heetch/migrate/migrate" for usage within Go.
 package main
 
 import (
 	"flag"
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/mattes/migrate/file"
-	"github.com/mattes/migrate/migrate"
-	"github.com/mattes/migrate/migrate/direction"
-	pipep "github.com/mattes/migrate/pipe"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/fatih/color"
+	"github.com/heetch/migrate/file"
+	"github.com/heetch/migrate/migrate"
+	"github.com/heetch/migrate/migrate/direction"
+	pipep "github.com/heetch/migrate/pipe"
 )
 
 var url = flag.String("url", os.Getenv("MIGRATE_URL"), "")

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -11,10 +11,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mattes/migrate/driver"
-	"github.com/mattes/migrate/file"
-	"github.com/mattes/migrate/migrate/direction"
-	pipep "github.com/mattes/migrate/pipe"
+	"github.com/heetch/migrate/driver"
+	"github.com/heetch/migrate/file"
+	"github.com/heetch/migrate/migrate/direction"
+	pipep "github.com/heetch/migrate/pipe"
 )
 
 // Up applies all available migrations
@@ -225,7 +225,7 @@ func Create(url, migrationsPath, name string) (*file.MigrationFile, error) {
 	version += 1
 	versionStr := strconv.FormatUint(version, 10)
 
-	length := 4 // TODO(mattes) check existing files and try to guess length
+	length := 4 // TODO(heetch) check existing files and try to guess length
 	if len(versionStr)%length != 0 {
 		versionStr = strings.Repeat("0", length-len(versionStr)%length) + versionStr
 	}


### PR DESCRIPTION
Context : 

The cassandra driver use to store migration number as a `counter`. That force us to name migration in a numerical order and make sure we never skip a number. Example : 

```
001_foo.up.cql
002_foo.up.cql
003_foo.up.cql
```

Will store `version = 3` in the database, so migrate will look for migration file starting at `4` 

```
001_foo.up.cql
003_foo.up.cql
004_foo.up.cql
```

Will also store `version = 3` in the database, so migrate will look for migration file starting at `4` and it will run `004_foo.up.cql` in the next migration causing failure because this migration as already been applied.

The strange thing here is, the order driver for SQL database do not work that way in migration.
So I open this PR to make the cassandra driver working like other SQL database driver.

Now the schema_migration are store with the version linked to the file. 
Plus I add some extract datas that may help in the futur
The result looks like this : 

```
cqlsh> select * from toto.schema_migrations;

 driver_version | version        | applied_at               | file_name
----------------+----------------+--------------------------+---------------------------------------------------
              1 | 20150810093212 | 2015-08-11 09:58:28+0200 | 20150810093212_change_weekday_and_timezone.up.cql
              1 | 20150730145034 | 2015-08-11 09:58:28+0200 |                        20150730145034_seed.up.cql
              1 | 20150730114823 | 2015-08-11 09:58:28+0200 |                        20150730114823_init.up.cql
```
